### PR TITLE
[Fix] historyChat 불러올 때, 복호화

### DIFF
--- a/ConvoPersona/src/main/java/OSS_group11/ConvoPersona/services/ChatService.java
+++ b/ConvoPersona/src/main/java/OSS_group11/ConvoPersona/services/ChatService.java
@@ -228,7 +228,7 @@ public class ChatService {
      * @param chatId
      * @return
      */
-    private String getHistoryMessages(Long chatId) {
+    private String getHistoryMessages(Long chatId) throws Exception {
         String historyMessage = "";
 
 
@@ -244,10 +244,10 @@ public class ChatService {
 
         for (Message message : allMessages) {
             if (message.getSender() == Sender.USER) {
-                historyMessage += "USER : " + message.getContent() + "\n";
+                historyMessage += "USER : " + encryptionService.decrypt(message.getContent()) + "\n";
             } else {
                 //Sender.GPT일 때
-                historyMessage += "GPT : " + message.getContent() + "\n";
+                historyMessage += "GPT : " + encryptionService.decrypt(message.getContent()) + "\n";
             }
         }
 


### PR DESCRIPTION
historyChat 불러올 때 DB에서 긁어오는데, DB에는 암호화되어있기 때문에 복호화해줘야함